### PR TITLE
Remove extra space in rssify

### DIFF
--- a/cgi-bin/grsshopper.pl
+++ b/cgi-bin/grsshopper.pl
@@ -2339,7 +2339,7 @@ sub format_rssify {		# Misc. clean-up for print
 
 	my ($text_ptr) = @_;
 
-	$$text_ptr =~ s/&(\w+?);/AMPERSAND$1; /g;
+	$$text_ptr =~ s/&(\w+?);/AMPERSAND$1;/g;
 	$$text_ptr =~ s/&/&amp;/mig;
 	$$text_ptr =~ s/AMPERSAND(\w+?);/&$1;/g;
 	$$text_ptr =~ s/AMPERSAND/&/mig;


### PR DESCRIPTION
Hi Stephen, 
perhaps the extra space is just a typo? It makes reading from the RSS feed a little more difficult. See the screenshot. But it is not really important, I just wanted to understand a bit of your code. 
Matthias 

![extra-space](https://user-images.githubusercontent.com/363449/28997008-6ecfeb44-7a0b-11e7-805b-417ecbd13f46.png)
